### PR TITLE
__stack_chk_fail.c: add missing string.h for memcpy

### DIFF
--- a/src/env/x86_64-xnu/__stack_chk_fail.c
+++ b/src/env/x86_64-xnu/__stack_chk_fail.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #include "atomic.h"
  
 uintptr_t __stack_chk_guard;


### PR DESCRIPTION
Fixes build error:
```
src/env/x86_64-xnu/__stack_chk_fail.c:9:15: error: implicit declaration of function 'memcpy' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if (entropy) memcpy(&__stack_chk_guard, entropy, sizeof(uintptr_t));
                     ^
1 error generated.
make: *** [obj/src/env/x86_64-xnu/__stack_chk_fail.o] Error 1
make: *** Waiting for unfinished jobs....
```